### PR TITLE
fix icon sizes

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -8,7 +8,7 @@
 ///
 /// Outputs base layout for a message container
 @mixin oMessageContainer () {
-	@include oTypographySans($scale: 0);
+	@include oTypographySans($o-message-typography-scale);
 	display: table;
 	// sass-lint:disable no-duplicate-properties
 	display: flex;
@@ -26,7 +26,7 @@
 ///
 /// Outputs styles for highligted message content
 @mixin oMessageHighlight {
-	@include oTypographySansBold($scale: 0);
+	@include oTypographySansBold($o-message-typography-scale);
 	line-height: 1;
 	margin-right: oTypographySpacingSize(6);
 	display: inline-block;
@@ -36,7 +36,7 @@
 ///
 /// Outputs styles for message content detail
 @mixin oMessageDetail {
-	padding-left: oTypographySpacingSize(2);
+	padding-left: oTypographySpacingSize(1);
 	font-weight: 400;
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,3 +17,14 @@ $o-message-class: o-message !default;
 // Alert message height
 $_o-message-alert-height: 48px;
 $_o-message-action-height: 40px;
+
+
+//Typography
+$o-message-typography-scale: 0 !default;
+
+//temporary until design confirms
+$_line-height: _oTypographyLineHeightFromScale($o-message-typography-scale, null);
+$_font-size: _oTypographyFontSizeFromScale($o-message-typography-scale);
+$_line-height-ratio: 1.5; //https://www.smashingmagazine.com/2009/08/typographic-design-survey-best-practices-from-the-best-blogs/#6-optimal-line-height-for-body-copy
+$_characters-per-line: 65;
+$_max-line-width: $_characters-per-line * ($_font-size / $_line-height-ratio);

--- a/src/scss/alert/_status.scss
+++ b/src/scss/alert/_status.scss
@@ -38,8 +38,9 @@
 					_oMessageGetMapValue($status, alert-icon-color),
 					_oMessageGetMapValue($status, alert-icon-size)
 				);
+				min-width: 40px;
+				padding: 0 4px;
 				vertical-align: middle;
-				padding: 4px 0;
 			}
 
 			.#{$class}__close {


### PR DESCRIPTION
This is a fix for #11 

The text width was causing the icons  to shrink a bit on the inner.
I've also added a temporary measure for maximum line width, until James decides what the width should be. At the moment it is 65 characters per line.

It would be nice to extract this into oTypography when the relevant decisions have been made.

Closes #11 