### PR TITLE
include line width cap for inner alert

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -25,10 +25,3 @@ $_o-message-close-icon-size: 20;
 
 //Typography
 $o-message-typography-scale: 0 !default;
-
-//temporary until design confirms
-$_line-height: _oTypographyLineHeightFromScale($o-message-typography-scale, null);
-$_font-size: _oTypographyFontSizeFromScale($o-message-typography-scale);
-$_line-height-ratio: 1.5; //https://www.smashingmagazine.com/2009/08/typographic-design-survey-best-practices-from-the-best-blogs/#6-optimal-line-height-for-body-copy
-$_characters-per-line: 65;
-$_max-line-width: $_characters-per-line * ($_font-size / $_line-height-ratio);

--- a/src/scss/alert/_inner.scss
+++ b/src/scss/alert/_inner.scss
@@ -42,4 +42,5 @@
 @mixin oMessageAlertInnerContent () {
 	@include oTypographyMargin($top: 3, $bottom: 0);
 	padding-left: $_o-message-alert-icon-size * 1px;
+	max-width: oTypographyMaxLineWidth($o-message-typography-scale);
 }


### PR DESCRIPTION
Uses the recently added `maxLineWidth` function from `oTypography`