### PR TITLE
shuffle actions  below text for alert/inner

### DIFF
--- a/demos/src/alert.mustache
+++ b/demos/src/alert.mustache
@@ -20,7 +20,7 @@
 			<div class="o-message__content">
 				<p class="o-message__content-main">
 					<span class="o-message__content-highlight">Meh.</span>
-					<span class="o-message__content-detail">There's a fox, and some lazy dogs.</span>
+					<span class="o-message__content-detail">There's a fox, and some lazy dogs. Many lazy dogs. Many, many, many lazy dogs. Only one fox. Many, many, many lazy dogs.</span>
 				</p>
 				<div class="o-message__actions">
 					<a href="#" class="o-message__actions__primary">Button</a>

--- a/src/scss/alert/_inner.scss
+++ b/src/scss/alert/_inner.scss
@@ -17,7 +17,7 @@
 			padding-left: $_o-message-alert-icon-size * 1px;
 
 			&-main {
-				@extend %o-message-inner-alert-notice-content-main ;
+				@extend %o-message-inner-alert-notice-content-main;
 			}
 
 			&-highlight {
@@ -26,9 +26,8 @@
 		}
 
 		.#{$class}__actions {
-			@extend %o-message-alert-notice-actions;
 			@include oTypographyPadding($bottom: 3);
-			margin-left: 0;
+			display: inline-block;
 		}
 	}
 }

--- a/src/scss/alert/_regular.scss
+++ b/src/scss/alert/_regular.scss
@@ -14,11 +14,7 @@
 
 	.#{$class}--alert,
 	.#{$class}--alert-bleed {
-		height: $_o-message-alert-height;
-
-		@include oGridRespondTo($until: S) {
-			height: 100%;
-		}
+		height: 100%;
 
 		.#{$class}__container:before {
 			top: ($_o-message-alert-height - $_o-message-alert-icon-size) / 2;
@@ -44,12 +40,10 @@
 		}
 
 		.#{$class}__actions {
-			@extend %o-message-alert-notice-actions;
+			@include oTypographyPadding($bottom: 1);
+			display: inline-block;
 
 			@include oGridRespondTo($until: S) {
-				@include oTypographyMargin($bottom: 2);
-				margin-left: 0;
-
 				&__secondary {
 					display: none;
 				}

--- a/src/scss/notice/_inner.scss
+++ b/src/scss/notice/_inner.scss
@@ -17,14 +17,13 @@
 			padding-left: 20px;
 
 			&-main {
-				@extend %o-message-inner-alert-notice-content-main ;
+				@extend %o-message-inner-alert-notice-content-main;
 			}
 		}
 
 		.#{$class}__actions {
-			@extend %o-message-alert-notice-actions;
 			@include oTypographyPadding($bottom: 3);
-			margin-left: 0;
+			display: inline-block;
 		}
 	}
 }

--- a/src/scss/notice/_regular.scss
+++ b/src/scss/notice/_regular.scss
@@ -24,7 +24,8 @@
 		}
 
 		.#{$class}__actions {
-			@extend %o-message-alert-notice-actions;
+			@include oTypographyPadding($bottom: 1);
+			display: inline-block;
 
 			@include oGridRespondTo($until: M) {
 				display: none;

--- a/src/scss/shared/_placeholders.scss
+++ b/src/scss/shared/_placeholders.scss
@@ -34,19 +34,10 @@
 	%o-message-alert-notice-content-main {
 		margin-top: (($_o-message-alert-height - $_o-message-line-height) / 2);
 		margin-bottom: (($_o-message-alert-height - $_o-message-line-height) / 2);
+		margin-right: oTypographySpacingSize(6);
 		display: inline-block;
 	}
 };
-
-// Action elements styling
-// Outputs actions layout
-@include _oMessageDefinePlaceholder(actions) {
-	%o-message-alert-notice-actions {
-		display: inline-block;
-		margin-left: oTypographySpacingSize(6);
-	}
-};
-
 
 // Inner alert message content styles
 // Outputs content layout


### PR DESCRIPTION
I thought we had fixed this bug, but it was only a fix for mobile 🙈 

With longer text, the buttons now shift below the text:
<img width="809" alt="screen shot 2018-04-11 at 11 29 38" src="https://user-images.githubusercontent.com/16777943/38611507-c5900a52-3d7b-11e8-9af5-bada1f926839.png">
