### PR TITLE
update close link to button and fix specificity

### DIFF
--- a/src/js/construct-element.js
+++ b/src/js/construct-element.js
@@ -92,10 +92,8 @@ export default {
 	* @returns {HTMLElement} Returns a new element to close the message
 	*/
 	closeButton: (opts) => {
-		const closeButton = document.createElement('a');
+		const closeButton = document.createElement('button');
 		closeButton.classList.add(`${opts.messageClass}__close`);
-		closeButton.setAttribute('role', 'button');
-		closeButton.setAttribute('href', '#void');
 		closeButton.setAttribute('aria-label', 'close');
 		closeButton.setAttribute('title', 'Close');
 

--- a/src/scss/alert/_inner.scss
+++ b/src/scss/alert/_inner.scss
@@ -10,6 +10,10 @@
 	.#{$class}--alert-inner {
 		.#{$class}__container {
 			@extend %o-message-inner-alert-notice-container;
+
+			.#{$class}__close {
+				right: oTypographySpacingSize(4);
+			}
 		}
 
 		.#{$class}__content {
@@ -30,8 +34,5 @@
 			display: inline-block;
 		}
 
-		.#{$class}__close {
-			right: oTypographySpacingSize(4);
-		}
 	}
 }

--- a/src/scss/notice/_inner.scss
+++ b/src/scss/notice/_inner.scss
@@ -10,6 +10,10 @@
 	.#{$class}--notice-inner {
 		.#{$class}__container {
 			@extend %o-message-inner-alert-notice-container;
+
+			.#{$class}__close {
+				right: oTypographySpacingSize(4);
+			}
 		}
 
 		.#{$class}__content {
@@ -30,8 +34,5 @@
 			display: inline-block;
 		}
 
-		.#{$class}__close {
-			right: oTypographySpacingSize(4);
-		} 
 	}
 }

--- a/src/scss/shared/_status.scss
+++ b/src/scss/shared/_status.scss
@@ -15,7 +15,7 @@
 			- success
 			- neutral
 			- error
-			
+
 			The available notice states are:
 			- inform
 			- warning
@@ -68,6 +68,7 @@
 		.#{$class}__close {
 			@include oMessageCloseButton(_oMessageGetMapValue($status, close-icon-color));
 			vertical-align: middle;
+			border: 0;
 		}
 	}
 }

--- a/test/contruct-element.test.js
+++ b/test/contruct-element.test.js
@@ -31,8 +31,7 @@ describe("constructElement", () => {
 					text: 'a link',
 					url: '#'
 				}
-			},
-			close: true
+			}
 		};
 	});
 
@@ -87,8 +86,7 @@ describe("constructElement", () => {
 						text: 'a link',
 						url: '#'
 					}
-				},
-				close: true
+				}
 			};
 		});
 

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -69,7 +69,7 @@ export default {
 				</div>
 			</div>
 		`,
-	closeButton: `<a class="my-message__close" role="button" href="#void" aria-label="close" title="Close"></a>`,
+	closeButton: `<button class="my-message__close" aria-label="close" title="Close"></button>`,
 	actions: `<div class="my-message__actions">
 			<a href="#" class="my-message__actions__primary">a button</a>
 			<a href="#" class="my-message__actions__secondary">a link</a>


### PR DESCRIPTION
This is a fix for #26, which makes the close link a button, which is semantically correct. And isn't a breaking as the button is created by the component and not included in the markup.


Closes #26.