### PR TITLE
Support inline links

### DIFF
--- a/src/scss/shared/_status.scss
+++ b/src/scss/shared/_status.scss
@@ -32,6 +32,16 @@
 		color: oColorsGetPaletteColor(_oMessageGet('foreground-color', $from: $status));
 		background-color: oColorsGetPaletteColor(_oMessageGet('background-color', $from: $status));
 
+		.#{$class}__content-main a,
+		.#{$class}__content-additional a {
+			@include oTypographyLinkCustom(
+				_oMessageGet('foreground-color', $from: $status),
+				_oMessageGet('foreground-color', $from: $status),
+				_oMessageGet('background-color', $from: $status)
+			);
+			border-width: 1px;
+		}
+
 		.#{$class}__actions__primary {
 			@include oMessageAlertButtonState(
 				_oMessageGet('background-color', $from: $status),


### PR DESCRIPTION
Chatted to James about inline links in `o-message` and we decided to use standard link styles with a 1px underline, similar to `o-footer` external links. I'll create an issue on `o-typography` to add a mixin which covers these usecases.

Before/after
<img width="726" alt="screen shot 2018-07-30 at 11 44 51" src="https://user-images.githubusercontent.com/10405691/43393153-004386f6-93ee-11e8-92b4-d1d56ed236e9.png">
<img width="721" alt="screen shot 2018-07-30 at 11 44 19" src="https://user-images.githubusercontent.com/10405691/43393154-03d88d66-93ee-11e8-91ad-347a361925fb.png">

Registry ui puts actions inline for inline notice links, which can be updated:
<img width="718" alt="screen shot 2018-07-30 at 11 39 22" src="https://user-images.githubusercontent.com/10405691/43393210-294cba7c-93ee-11e8-8436-a38fb3ff4cd6.png">
<img width="721" alt="screen shot 2018-07-30 at 11 39 37" src="https://user-images.githubusercontent.com/10405691/43393212-2a86b9ba-93ee-11e8-8400-2983ac23c91d.png">

With actions also (not recommended)
<img width="434" alt="screen shot 2018-07-30 at 11 27 14" src="https://user-images.githubusercontent.com/10405691/43392832-c4b9aa58-93ec-11e8-9054-c9c1d8f76e83.png">
