### PR TITLE
Get color name from palette in oMessageAlertLink

### DIFF
--- a/src/scss/shared/_mixins.scss
+++ b/src/scss/shared/_mixins.scss
@@ -44,11 +44,11 @@
 	white-space: nowrap;
 
 	&:hover {
-		border-bottom-color: $link-hover; // is different to custom link hover by design.
+		border-bottom-color: oColorsGetPaletteColor($link-hover); // is different to custom link hover by design.
 	}
 
 	&:focus {
-		outline: 3px solid $link-focus;
+		outline: 3px solid oColorsGetPaletteColor($link-focus);
 		border-bottom-color: transparent;
 	}
 }


### PR DESCRIPTION
Avoids: `.o-message__actions__secondary:hover{border-bottom-color:black-jade-43}`