### PR TITLE
Add option to open action links in a `_blank` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ The following options are not required, and all have a default value:
 	- `primary`:  Object. Holds the following values for button properties:
 		- `text`: String. text value of the button. Defaults to `null`
 		- `url`: String. The URL the button links to. Defaults to `#`
+		- `openInNewWindow`: Boolean. Decides if the action should open with `target="_blank`. Defaults to `false`
 	- `secondary`: Object. Holds the following values for link properties:
 		- `text`: String. text value of the link. Defaults to `null`
 		- `url`: String. The URL the link links to. Defaults to `#`
+		- `openInNewWindow`: Boolean. Decides if the action should open with `target="_blank`. Defaults to `false`
 - `close`: Boolean. Whether or not to display the close button. Defaults to `true`.
 
 ### Sass

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -5,12 +5,12 @@ const throwError = (message) => {
 const buildActions = (opts) => {
 	let primaryActionHTML;
 	if (opts.actions.primary && opts.actions.primary.text) {
-		primaryActionHTML = `<a href="${opts.actions.primary.url}" class="${opts.messageClass}__actions__primary">${opts.actions.primary.text}</a>`;
+		primaryActionHTML = `<a href="${opts.actions.primary.url}" class="${opts.messageClass}__actions__primary" ${opts.actions.primary.openInNewWindow ? `target="_blank" aria-label="${opts.actions.primary.text} (opens in new window)"` : ''}>${opts.actions.primary.text}</a>`;
 	}
 
 	let secondaryActionHTML;
 	if (opts.actions.secondary && opts.actions.secondary.text) {
-		secondaryActionHTML = `<a href="${opts.actions.secondary.url}" class="${opts.messageClass}__actions__secondary">${opts.actions.secondary.text}</a>`;
+		secondaryActionHTML = `<a href="${opts.actions.secondary.url}" class="${opts.messageClass}__actions__secondary" ${opts.actions.secondary.openInNewWindow ? `target="_blank" aria-label="${opts.actions.secondary.text} (opens in new window)"` : ''}>${opts.actions.secondary.text}</a>`;
 	}
 
 	let actions = `<div class="${opts.messageClass}__actions">

--- a/src/js/message.js
+++ b/src/js/message.js
@@ -43,11 +43,13 @@ class Message {
 			actions: {
 				primary: {
 					text: null,
-					url: '#'
+					url: '#',
+					openInNewWindow: false
 				},
 				secondary: {
 					text: null,
-					url: '#'
+					url: '#',
+					openInNewWindow: false
 				}
 			},
 			close: options && options.close ? options.close : true

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -26,7 +26,7 @@ describe("constructElement", () => {
 				primary: {
 					text: 'a button',
 					url: '#',
-					openInNewWindow: true
+					openInNewWindow: false
 				},
 				secondary: {
 					text: 'a link',
@@ -38,7 +38,20 @@ describe("constructElement", () => {
 		};
 	});
 
-	it('builds an actions element', () => {
-		assert.strictEqual(flatten(buildActions(options)), flatten(fixtures.actions));
+	context('with `openInNewWindow` as false', () => {
+		it('builds an actions element', () => {
+			assert.strictEqual(flatten(buildActions(options)), flatten(fixtures.actions));
+		});
+	});
+
+	context('with `openInNewWindow` as true', () => {
+		beforeEach(() => {
+			options.actions.primary.openInNewWindow = true;
+			options.actions.secondary.openInNewWindow = true;
+		});
+
+		it('builds an actions element', () => {
+			assert.strictEqual(flatten(buildActions(options)), flatten(fixtures.actionsNewWindow));
+		});
 	});
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -25,11 +25,13 @@ describe("constructElement", () => {
 			actions: {
 				primary: {
 					text: 'a button',
-					url: '#'
+					url: '#',
+					openInNewWindow: true
 				},
 				secondary: {
 					text: 'a link',
-					url: '#'
+					url: '#',
+					openInNewWindow: false
 				}
 			},
 			close: true

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -71,8 +71,12 @@ export default {
 		`,
 	closeButton: `<button class="my-message__close" aria-label="close" title="Close"></button>`,
 	actions: `<div class="my-message__actions">
-			<a href="#" class="my-message__actions__primary" target="_blank" aria-label="a button (opens in new window)">a button</a>
+			<a href="#" class="my-message__actions__primary">a button</a>
 			<a href="#" class="my-message__actions__secondary">a link</a>
 			</div>
-		`
+		`,
+	actionsNewWindow: `<div class="my-message__actions">
+			<a href="#" class="my-message__actions__primary" target="_blank" aria-label="a button (opens in new window)">a button</a>
+			<a href="#" class="my-message__actions__secondary" target="_blank" aria-label="a link (opens in new window)">a link</a>
+			</div>`
 };

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -71,7 +71,7 @@ export default {
 		`,
 	closeButton: `<button class="my-message__close" aria-label="close" title="Close"></button>`,
 	actions: `<div class="my-message__actions">
-			<a href="#" class="my-message__actions__primary">a button</a>
+			<a href="#" class="my-message__actions__primary" target="_blank" aria-label="a button (opens in new window)">a button</a>
 			<a href="#" class="my-message__actions__secondary">a link</a>
 			</div>
 		`

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -70,11 +70,13 @@ describe("Message", () => {
 				actions: {
 					primary: {
 						text: null,
-						url: '#'
+						url: '#',
+						openInNewWindow: false
 					},
 					secondary: {
 						text: null,
-						url: '#'
+						url: '#',
+						openInNewWindow: false
 					}
 				},
 				close: true


### PR DESCRIPTION
Introduces the `openInNewWindow` option to both the primary and secondary actions.

When `true`, actions will have `target="_blank"` and an `aria-label` indicating link will open in a new window to users using assistive technology.