### PR TITLE
Remove "height:100%" from alert messages.

### DIFF
--- a/src/scss/alert/_regular.scss
+++ b/src/scss/alert/_regular.scss
@@ -14,7 +14,6 @@
 
 	.#{$class}--alert,
 	.#{$class}--alert-bleed {
-		height: 100%;
 
 		.#{$class}__container:before {
 			top: $_o-message-text-spacing / 2;


### PR DESCRIPTION
Prevents this:
<img width="1414" alt="screen shot 2018-11-14 at 10 53 48" src="https://user-images.githubusercontent.com/10405691/48478237-9fe20f00-e7fb-11e8-9d10-aceced16e9e6.png">