### PR TITLE
Remove deprecated elseif

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -46,12 +46,16 @@
 				padding-left: $_o-message-spacing;
 			}
 
-		} @elseif $type == 'notice' {
+		}
+
+		@if $type == 'notice' {
 			.o-message__content {
 				padding-left: $_o-message-spacing / 2;
 			}
 
-		} @elseif $type == 'action' {
+		}
+
+		@if $type == 'action' {
 			.o-message__content {
 				padding: oTypographySpacingSize(4) 0;
 


### PR DESCRIPTION
Dart-sass has deprecated `@elseif`. `@else if` should be used instead. However in this case, I opted for plain `@if` which I think is easier to read.