### PR TITLE
Increase specificity of state and type modifiers

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -42,7 +42,7 @@
 /// Outputs base styles for an type of message
 /// @access private
 @mixin _oMessageType($type) {
-	.o-message--#{$type} {
+	.o-message.o-message--#{$type} {
 		@if $type == 'alert' {
 			.o-message__content {
 				padding-left: $_o-message-spacing;

--- a/src/scss/_state.scss
+++ b/src/scss/_state.scss
@@ -9,7 +9,7 @@
 	$background-color: _oMessageGet('background-color', $from: $state);
 	$background-color: if(type-of($background-color) == 'string', oColorsByName($background-color), $background-color);
 
-	.o-message--#{$state} {
+	.o-message.o-message--#{$state} {
 		color: $foreground-color;
 		background-color: $background-color;
 


### PR DESCRIPTION
it would be good if source order didn't affect the behaviour of modifiers.

From Edd: 

> Challenging specificity bug, .o-message--inform overrides link colours from a standard o-message but due to :magic: the o-message-inform styles are being extracted out onto the page, before the stylesheet so the o-message styles take precedence

it would be good if source order didn't affect the behaviour of modifiers.

i think i'd prefer if the base styles were pulled out to a `.o-message--basic`, but that's definitely a breaking change while this is only arguably a breaking change.