### PR TITLE
Replace "status" references with "states".

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ If you're setting up a message without existing DOM elements, `Message` will con
 import Message from 'o-message';
 const importantMessage = new Message(null, {
 	type: 'alert',
-	status: 'error',
+	state: 'error',
 	content: {
 		highlight: 'Something has gone wrong.',
 		detail: 'The quick brown fox did not jump over the lazy dogs.'
@@ -188,7 +188,7 @@ const importantMessage = new Message(null, {
 
 The only required options are listed in the example _above_. These are:
 - `type`: String. The o-message variant. The available variants are 'action', 'alert' and 'notice'.
-- `status`: String. All messages require a status, and you must supply one that combines with the type of message you've chosen, as listed in the [message types](#message-types)
+- `state`: String. All messages require a state, and you must supply one that combines with the type of message you've chosen, as listed in the [message types](#message-types)
 - `content.detail`: String. The detail about the nature of a message.
 
 The following options are not required, and all have a default value:
@@ -215,7 +215,7 @@ For example, to configure the `close` icon to not display:
 import Message from 'o-message';
 const importantMessage = new Message(null, {
 	type: 'alert',
-	status: 'error',
+	state: 'error',
 	content: {
 -		highlight: 'Something has gone wrong.',
 +		highlight: 'Something has gone very wrong.',

--- a/demos/src/message-template.mustache
+++ b/demos/src/message-template.mustache
@@ -1,5 +1,5 @@
 {{#inner}}<div class="demo-inner-message">{{/inner}}
-	<div class="o-message o-message--{{type}} {{#inner}}o-message--inner{{/inner}} o-message--{{status}}" data-o-component="o-message" {{#noCloseButton}}data-close="false"{{/noCloseButton}}>
+	<div class="o-message o-message--{{type}} {{#inner}}o-message--inner{{/inner}} o-message--{{state}}" data-o-component="o-message" {{#noCloseButton}}data-close="false"{{/noCloseButton}}>
 		<div class="o-message__container">
 			<div class="o-message__content {{#centralised}}o-message__content--center-align{{/centralised}}">
 				<p class="o-message__content-main">

--- a/origami.json
+++ b/origami.json
@@ -36,7 +36,7 @@
 			"description": "Alert message for a positive response to an action",
 			"data": {
 				"type": "alert",
-				"status": "success",
+				"state": "success",
 				"highlight": "Hooray!",
 				"content": "The quick brown fox jumped over the lazy dogs!",
 				"actions": {
@@ -52,7 +52,7 @@
 			"data": {
 				"inner": true,
 				"type": "alert",
-				"status": "success",
+				"state": "success",
 				"highlight": "Hooray!",
 				"content": "The quick brown fox jumped over the lazy dogs!",
 				"additionalContent": "Did you know that that sentence uses all of the letters in the alphabet at least once?",
@@ -68,7 +68,7 @@
 			"description": "Alert message for an informative response to an action",
 			"data": {
 				"type": "alert",
-				"status": "neutral",
+				"state": "neutral",
 				"content": "There's a fox, and some lazy dogs. Many lazy dogs. Many, many, many lazy dogs. Only one fox. Many, many, many lazy dogs.",
 				"actions": {
 					"button": true,
@@ -83,7 +83,7 @@
 			"data": {
 				"inner": true,
 				"type": "alert",
-				"status": "neutral",
+				"state": "neutral",
 				"highlight": "Meh.",
 				"detail": "The quick brown fox did not jump over the lazy dogs.",
 				"actions": {
@@ -98,7 +98,7 @@
 			"description": "Alert message for a negative response to an action",
 			"data": {
 				"type": "alert",
-				"status": "error",
+				"state": "error",
 				"content": "The quick brown fox did <span class='o-message__content-highlight'>not</span> jump over the lazy dogs.",
 				"actions": {
 					"button": true,
@@ -113,7 +113,7 @@
 			"data": {
 				"inner": true,
 				"type": "alert",
-				"status": "error",
+				"state": "error",
 				"highlight": "Oops.",
 				"content": "The quick brown fox did <span class='o-message__content-highlight'>not</span> jump over the lazy dogs.",
 				"additionalContent": "But that sentence still uses all of the letters in the alphabet at least once!",
@@ -129,7 +129,7 @@
 			"description": "Notice message to convey information",
 			"data": {
 				"type": "notice",
-				"status": "inform",
+				"state": "inform",
 				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact.",
 				"actions": {
 					"button": true,
@@ -144,7 +144,7 @@
 			"data": {
 				"inner": true,
 				"type": "notice",
-				"status": "inform",
+				"state": "inform",
 				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact.",
 				"actions": {
 					"button": true,
@@ -159,7 +159,7 @@
 			"description": "Notice message to emit a light warning",
 			"data": {
 				"type": "notice",
-				"status": "warning-light",
+				"state": "warning-light",
 				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact."
 			},
 			"brands": [
@@ -173,7 +173,7 @@
 			"data": {
 				"inner": true,
 				"type": "notice",
-				"status": "warning-light",
+				"state": "warning-light",
 				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact. There may also be a fox. This is unconfirmed.",
 				"actions": {
 					"button": true,
@@ -191,7 +191,7 @@
 			"description": "Notice message to emit a strong warning",
 			"data": {
 				"type": "notice",
-				"status": "warning",
+				"state": "warning",
 				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact."
 			},
 			"brands": [
@@ -205,7 +205,7 @@
 			"data": {
 				"inner": true,
 				"type": "notice",
-				"status": "warning",
+				"state": "warning",
 				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact. There may also be a fox. This is unconfirmed."
 			},
 			"brands": [
@@ -218,7 +218,7 @@
 			"description": "Action message, displaying a call to action",
 			"data":  {
 				"type": "action",
-				"status": "inform-inverse",
+				"state": "inform-inverse",
 				"centralised": true,
 				"content": "The quick brown fox did <span class='o-message__content-highlight'>not</span> jump over the lazy dogs.",
 				"actions": {

--- a/src/js/message.js
+++ b/src/js/message.js
@@ -18,7 +18,7 @@ class Message {
 	 * @example To construct a message which does not already exist on the page.
  	 *      const errorAlert = new Message(null, {
  	 *      	type: 'alert',
- 	 *      	status: 'error',
+ 	 *      	state: 'error',
  	 *      	content: {
  	 *      		highlight: 'Something has gone wrong.',
  	 *      		detail: 'The quick brown fox did not jump over the lazy dogs.'

--- a/src/scss/_state.scss
+++ b/src/scss/_state.scss
@@ -1,5 +1,5 @@
-/// message status styling
-/// @param {String} $state - the name of the status for the message ('success', 'neutral', 'error', 'warning', 'warning-light', 'inform', 'inform-inverse')
+/// message state styling
+/// @param {String} $state - the name of the state for the message ('success', 'neutral', 'error', 'warning', 'warning-light', 'inform', 'inform-inverse')
 /// @access private
 @mixin _oMessageState ($state) {
 	// get foreground colour

--- a/test/contruct-element.test.js
+++ b/test/contruct-element.test.js
@@ -52,7 +52,7 @@ describe("constructElement", () => {
 			assert.throws(() => construct.message(mockObj.opts), error);
 		});
 
-		it('throws an error if no status is defined', () => {
+		it('throws an error if no state is defined', () => {
 			mockObj.opts.state = null;
 
 			let error = "*** o-message error:\nMessages require a state.\n***";
@@ -107,7 +107,7 @@ describe("constructElement", () => {
 			assert.strictEqual(flatten(construct.message(mockObj.opts).innerHTML), flatten(fixtures.notice));
 		});
 
-		it('throws an error if no status is defined', () => {
+		it('throws an error if no state is defined', () => {
 			mockObj.opts.state = null;
 
 			let error = "*** o-message error:\nMessages require a state.\n***";

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -131,7 +131,7 @@ describe("Message", () => {
 
 			beforeEach(() => {
 				options = {
-					status: 'success',
+					state: 'success',
 					type: 'alert',
 					content: {
 						highlight: 'Good.'


### PR DESCRIPTION
- Corrects documentation.
- Uses o-message naming consistency in tests etc.

It appears "status" may have become "state" in v3.