### PR TITLE
Add support for custom message states.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ o-message [![Circle CI](https://circleci.com/gh/Financial-Times/o-message/tree/m
 It can be initialised declaratively if markup is provided on the page, or it can be initialised imperatively when using the [manual build process](http://origami.ft.com/docs/developer-guide/modules/building-modules/).
 
 ### Message Types
-`o-message` provides three types of messages: **action**, **alert**, and **notice**.
+`o-message` provides three types of messages: **alert**, **notice**, and **action**.
 
-- An **action** message should be used as a static call to action, that is not necessarily a response to a user's interaction with a product (e.g. requesting feedback in general).
-
-- An **alert** message should be used as feedback to a users interaction with a product (e.g. payment declined warning)
+- An **alert** message should be used as feedback to a users interaction with a product (e.g. payment declined warning). Unlike other messages, alert messages have an icon.
 
 - A **notice** message should be used to provide information or warnings about a product. (e.g. beta version of a product).
+
+- An **action** message should be used as a static call to action, usually within or below main content, that is not necessarily a response to a user's interaction with a product (e.g. requesting feedback in general).
+
 
 You can find a demo for each of the messages above in the [Origami registry](https://registry.origami.ft.com/components/o-message).
 
@@ -143,6 +144,22 @@ For any message, you can highlight any portion of copy within a paragraph by usi
 </div>
 ```
 
+[Sass](#sass) users may create custom messages with a highlight colour. This is useful to highlight key words in the message. To apply the highlight colour to message copy use the class `o-message__content-highlight-color`.
+```html
+<div class="o-message o-message--alert o-message--success" data-o-component="o-message">
+	<div class="o-message__container">
+		<div class="o-message__content">
+				<p class="o-message__content-main">
+					<span class="o-message__content-highlight">
+						Hurray<span class="o-message__content-highlight-color">thing</span>happened
+					</span>
+					The quick brown fox jumped over the lazy dogs!
+				</p>
+		</div>
+	</div>
+</div>
+```
+
 For **action messages only**, you can centralise the text with a specific class (`.o-message__content--center-align`):
 ```diff
 <div class="o-message o-message--action o-message--inform" data-o-component="o-message">
@@ -249,6 +266,35 @@ Options include:
 | types               | The message to support (e.g. alert, notice, action) see [message types](#message-types).                                                    |
 | state               | The kinds of messages to support (e.g. 'inform', 'warning', 'error') see [message types](#message-types).                                   |
 | layouts             | By default messages should span the page, to support messages within content pass the 'inner' option. See [message types](#message-types).  |
+
+#### Custom Message
+
+To create a new message with a unique look call `oMessageAddSate`. The mixin accepts three arguments:
+
+- `name`: The name of your state. This is used for the modifier class output o-message--{name}.
+- `opts`: A map of options for your state. Note colours may be an [o-colors](https://registry.origami.ft.com/components/o-colors) colour name or a hex value:
+    - `foreground-color`: The colour used for message text, and the button where a highlight colour has not been given.
+	- `background-color`: The background colour used for the message.
+	- `icon`: The [o-icons](https://registry.origami.ft.com/components/o-icons) icon name to show in an alert message. Required only for your state to support an alert message type.
+	- `button-type` (optional): The type of [o-buttons](https://registry.origami.ft.com/components/o-buttons) button the message should have. One of `primary` or `secondary` (defaults to `secondary`).
+	- `highlight-color` (optional): The highlight colour is used for the message button. It can also be used to highlight message copy with the CSS class `o-message__content-highlight-color`.
+	- `highlight-text-transform` (optional): Use to set the `text-transform` property to of copy within the `o-message__content-highlight` element, e.g. to `uppercase` highlighted copy.
+- `types`: A list of [message types](#message-types) your state supports, one or more of (`alert`, `notice`, `action`).
+
+```scss
+// Outputs CSS for a custom message state called "pikachu"
+// Outputs a modifier class `o-message--pikachu`
+@include oMessageAddState(
+	$name: 'pikachu', // the custom state is named "pikachu"
+	$opts: (
+	'background-color': 'slate', // slate message
+	'foreground-color': 'white', // white text
+	'highlight-color': 'lemon', // lemon highlights with `o-message__content-highlight-color` and a lemon button
+	'button-type': 'primary', // a primary o-buttons button
+	'highlight-text-transform': 'uppercase', // uppercase `o-message__content-highlight` highlight copy
+	'icon': 'user', // show a 'user' o-icons icon if used as an alert
+), $types: ('notice', 'alert')); // this state should work with notice and alert message types
+```
 
 ## Migration
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ To create a new message with a unique look call `oMessageAddSate`. The mixin acc
 	- `icon`: The [o-icons](https://registry.origami.ft.com/components/o-icons) icon name to show in an alert message. Required only for your state to support an alert message type.
 	- `button-type` (optional): The type of [o-buttons](https://registry.origami.ft.com/components/o-buttons) button the message should have. One of `primary` or `secondary` (defaults to `secondary`).
 	- `highlight-color` (optional): The highlight colour is used for the message button. It can also be used to highlight message copy with the CSS class `o-message__content-highlight-color`.
-	- `highlight-text-transform` (optional): Use to set the `text-transform` property to of copy within the `o-message__content-highlight` element, e.g. to `uppercase` highlighted copy.
 - `types`: A list of [message types](#message-types) your state supports, one or more of (`alert`, `notice`, `action`).
 
 ```scss
@@ -290,8 +289,7 @@ To create a new message with a unique look call `oMessageAddSate`. The mixin acc
 	'background-color': 'slate', // slate message
 	'foreground-color': 'white', // white text
 	'highlight-color': 'lemon', // lemon highlights with `o-message__content-highlight-color` and a lemon button
-	'button-type': 'primary', // a primary o-buttons button
-	'highlight-text-transform': 'uppercase', // uppercase `o-message__content-highlight` highlight copy
+	'button-type': 'primary', // a primary o-buttons button`o-message__content-highlight` highlight copy
 	'icon': 'user', // show a 'user' o-icons icon if used as an alert
 ), $types: ('notice', 'alert')); // this state should work with notice and alert message types
 ```

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -24,3 +24,12 @@ body {
 	margin: auto;
 	max-width: 400px;
 }
+
+@include oMessageAddState('pikachu', (
+	'foreground-color': 'white',
+	'background-color': 'slate',
+	'highlight-color': 'lemon',
+	'button-type': 'primary',
+	'highlight-text-transform': 'uppercase',
+	'icon': 'user',
+), $types: ('notice', 'alert'));

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -30,6 +30,5 @@ body {
 	'background-color': 'slate',
 	'highlight-color': 'lemon',
 	'button-type': 'primary',
-	'highlight-text-transform': 'uppercase',
 	'icon': 'user',
 ), $types: ('notice', 'alert'));

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -59,25 +59,20 @@ const initDemos = () => {
 	setUpDemo('alert-success', options, {state: 'success'});
 	setUpDemo('alert-neutral', options, {state: 'neutral'});
 	setUpDemo('alert-error', options, {state: 'error'});
-	setUpDemo('alert-pikachu', options, { state: 'pikachu'});
 
 	setUpDemo('notice-inform', options, {type: 'notice', state: 'inform'});
 	setUpDemo('notice-warning', options, {type: 'notice', state: 'warning'});
 	setUpDemo('notice-warning-light', options, {type: 'notice', state: 'warning-light'});
-	setUpDemo('notice-pikachu', options, {type: 'notice', state: 'pikachu'});
 
 	setUpDemo('inner-alert-success', innerOptions, {state: 'success'});
 	setUpDemo('inner-alert-neutral', innerOptions, {state: 'neutral'});
 	setUpDemo('inner-alert-error', innerOptions, {state: 'error', actions: null});
-	setUpDemo('inner-alert-pikachu', innerOptions, { state: 'pikachu', actions: null});
 
 	setUpDemo('inner-notice-inform', innerOptions, {type: 'notice', state: 'inform'});
 	setUpDemo('inner-notice-warning', innerOptions, {type: 'notice', state: 'warning'});
 	setUpDemo('inner-notice-warning-light', innerOptions, {type: 'notice', state: 'warning-light'});
-	setUpDemo('inner-notice-pikachu', innerOptions, { type: 'notice', state: 'pikachu'});
 
 	setUpDemo('action-inform-inverse', actionOptions, {type: 'action', state: 'inform-inverse'});
-	setUpDemo('action-inform-pikachu', actionOptions, { type: 'action', state: 'pikachu'});
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -59,20 +59,25 @@ const initDemos = () => {
 	setUpDemo('alert-success', options, {state: 'success'});
 	setUpDemo('alert-neutral', options, {state: 'neutral'});
 	setUpDemo('alert-error', options, {state: 'error'});
+	setUpDemo('alert-pikachu', options, { state: 'pikachu'});
 
 	setUpDemo('notice-inform', options, {type: 'notice', state: 'inform'});
 	setUpDemo('notice-warning', options, {type: 'notice', state: 'warning'});
 	setUpDemo('notice-warning-light', options, {type: 'notice', state: 'warning-light'});
+	setUpDemo('notice-pikachu', options, {type: 'notice', state: 'pikachu'});
 
 	setUpDemo('inner-alert-success', innerOptions, {state: 'success'});
 	setUpDemo('inner-alert-neutral', innerOptions, {state: 'neutral'});
 	setUpDemo('inner-alert-error', innerOptions, {state: 'error', actions: null});
+	setUpDemo('inner-alert-pikachu', innerOptions, { state: 'pikachu', actions: null});
 
 	setUpDemo('inner-notice-inform', innerOptions, {type: 'notice', state: 'inform'});
 	setUpDemo('inner-notice-warning', innerOptions, {type: 'notice', state: 'warning'});
 	setUpDemo('inner-notice-warning-light', innerOptions, {type: 'notice', state: 'warning-light'});
+	setUpDemo('inner-notice-pikachu', innerOptions, { type: 'notice', state: 'pikachu'});
 
 	setUpDemo('action-inform-inverse', actionOptions, {type: 'action', state: 'inform-inverse'});
+	setUpDemo('action-inform-pikachu', actionOptions, { type: 'action', state: 'pikachu'});
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/demos/src/imperative.mustache
+++ b/demos/src/imperative.mustache
@@ -3,9 +3,13 @@
 	<button class="demo-button" id="alert-success">Success Alert</button>
 	<button class="demo-button" id="alert-neutral">Neutral Alert</button>
 	<button class="demo-button" id="alert-error">Error Alert</button>
+	<button class="demo-button" id="alert-pikachu">Pikachu Alert</button>
+
 	<button class="demo-button" id="inner-alert-success">Success Alert (Inner)</button>
 	<button class="demo-button" id="inner-alert-neutral">Information Alert (Inner)</button>
 	<button class="demo-button" id="inner-alert-error">Error Alert (Inner)</button>
+
+	<button class="demo-button" id="inner-alert-pikachu">Pikachu Alert (Inner)</button>
 </div>
 
 <h6>Notice messages</h6>
@@ -13,14 +17,21 @@
 	<button class="demo-button" id="notice-inform">Inform Notice</button>
 	<button class="demo-button" id="notice-warning">Warning Notice</button>
 	<button class="demo-button" id="notice-warning-light">Light Warning Notice</button>
+
+	<button class="demo-button" id="notice-pikachu">Pikachu Notice</button>
+
 	<button class="demo-button" id="inner-notice-inform">Inform Notice (Inner)</button>
 	<button class="demo-button" id="inner-notice-warning">Warning Notice (Inner)</button>
 	<button class="demo-button" id="inner-notice-warning-light">Light Warning Notice (Inner)</button>
+
+	<button class="demo-button" id="inner-notice-pikachu">Pikachu Notice (Inner)</button>
 </div>
 
 <h6>Action messages</h6>
 <div class="list-of-demo-buttons">
 	<button class="demo-button" id="action-inform-inverse">Inform-Inverse Action</button>
+
+	<button class="demo-button" id="action-pikachu">Pikachu Action</button>
 </div>
 
 <div class="demo-inner"></div>

--- a/demos/src/imperative.mustache
+++ b/demos/src/imperative.mustache
@@ -3,13 +3,10 @@
 	<button class="demo-button" id="alert-success">Success Alert</button>
 	<button class="demo-button" id="alert-neutral">Neutral Alert</button>
 	<button class="demo-button" id="alert-error">Error Alert</button>
-	<button class="demo-button" id="alert-pikachu">Pikachu Alert</button>
 
 	<button class="demo-button" id="inner-alert-success">Success Alert (Inner)</button>
 	<button class="demo-button" id="inner-alert-neutral">Information Alert (Inner)</button>
 	<button class="demo-button" id="inner-alert-error">Error Alert (Inner)</button>
-
-	<button class="demo-button" id="inner-alert-pikachu">Pikachu Alert (Inner)</button>
 </div>
 
 <h6>Notice messages</h6>
@@ -18,20 +15,15 @@
 	<button class="demo-button" id="notice-warning">Warning Notice</button>
 	<button class="demo-button" id="notice-warning-light">Light Warning Notice</button>
 
-	<button class="demo-button" id="notice-pikachu">Pikachu Notice</button>
 
 	<button class="demo-button" id="inner-notice-inform">Inform Notice (Inner)</button>
 	<button class="demo-button" id="inner-notice-warning">Warning Notice (Inner)</button>
 	<button class="demo-button" id="inner-notice-warning-light">Light Warning Notice (Inner)</button>
-
-	<button class="demo-button" id="inner-notice-pikachu">Pikachu Notice (Inner)</button>
 </div>
 
 <h6>Action messages</h6>
 <div class="list-of-demo-buttons">
 	<button class="demo-button" id="action-inform-inverse">Inform-Inverse Action</button>
-
-	<button class="demo-button" id="action-pikachu">Pikachu Action</button>
 </div>
 
 <div class="demo-inner"></div>

--- a/demos/src/message-template.mustache
+++ b/demos/src/message-template.mustache
@@ -3,8 +3,21 @@
 		<div class="o-message__container">
 			<div class="o-message__content {{#centralised}}o-message__content--center-align{{/centralised}}">
 				<p class="o-message__content-main">
-					{{#highlight}}<span class="o-message__content-highlight">{{highlight}}</span>{{/highlight}}
-					{{#detail}}<span class="o-message__content-detail">The quick brown fox did not jump over the lazy dogs.</span>{{/detail}}
+					{{#highlight.length}}
+						<span class="o-message__content-highlight">
+						{{#highlight}}
+							{{#color}}
+								<span class="o-message__content-highlight-color">{{copy}}</span>
+							{{/color}}
+							{{^color}}
+								{{copy}}
+							{{/color}}
+						{{/highlight}}
+						</span>
+					{{/highlight.length}}
+					{{#detail}}
+						<span class="o-message__content-detail">The quick brown fox did not jump over the lazy dogs.</span>
+					{{/detail}}
 					{{{content}}}
 				</p>
 				{{#additionalContent}}<p class="o-message__content-additional">{{additionalContent}}</p>{{/additionalContent}}

--- a/main.scss
+++ b/main.scss
@@ -37,7 +37,12 @@
 
 	@each $state in $states {
 		@if index($o-message-states, $state) and _oMessageSupports($state) {
-			@include _oMessageState($state);
+			$state-types: map-get($_o-message-states-to-types, $state);
+			@include oMessageAddState(
+				$name: $state,
+				$opts: null,
+				$types: $state-types
+			);
 		}
 	}
 

--- a/origami.json
+++ b/origami.json
@@ -37,7 +37,7 @@
 			"data": {
 				"type": "alert",
 				"state": "success",
-				"highlight": "Hooray!",
+				"highlight": [{"copy": "Hooray!", "color": false}],
 				"content": "The quick brown fox jumped over the lazy dogs!",
 				"actions": {
 					"button": true,
@@ -53,7 +53,7 @@
 				"inner": true,
 				"type": "alert",
 				"state": "success",
-				"highlight": "Hooray!",
+				"highlight": [{"copy": "Hooray!", "color": false}],
 				"content": "The quick brown fox jumped over the lazy dogs!",
 				"additionalContent": "Did you know that that sentence uses all of the letters in the alphabet at least once?",
 				"actions": {
@@ -84,7 +84,7 @@
 				"inner": true,
 				"type": "alert",
 				"state": "neutral",
-				"highlight": "Meh.",
+				"highlight": [{"copy": "Meh.", "color": false}],
 				"detail": "The quick brown fox did not jump over the lazy dogs.",
 				"actions": {
 					"button": true,
@@ -114,7 +114,7 @@
 				"inner": true,
 				"type": "alert",
 				"state": "error",
-				"highlight": "Oops.",
+				"highlight": [{"copy": "Oops.", "color": false}],
 				"content": "The quick brown fox did <span class='o-message__content-highlight'>not</span> jump over the lazy dogs.",
 				"additionalContent": "But that sentence still uses all of the letters in the alphabet at least once!",
 				"actions": {
@@ -226,6 +226,105 @@
 				},
 				"noCloseButton": true
 			},
+			"brands": [
+				"internal"
+			]
+		},
+		{
+			"title": "Alert: Custom",
+			"name": "alert-custom",
+			"description": "Sass users may customise alert messages. See the README for more information.",
+			"data": {
+				"type": "alert",
+				"state": "pikachu",
+				"highlight": [
+					{
+						"copy": "Hurray",
+						"color": false
+					},
+					{
+						"copy": "thing",
+						"color": true
+					},
+					{
+						"copy": "happened",
+						"color": false
+					}
+				],
+				"content": "The quick brown fox jumped over the lazy dogs!",
+				"actions": {
+					"button": true,
+					"link": true
+				}
+			},
+			"display_html": false,
+			"brands": [
+				"master",
+				"internal"
+			]
+		},
+		{
+			"title": "Notice: Custom",
+			"name": "notice-custom",
+			"description": "Sass users may customise notice messages. See the README for more information.",
+			"data": {
+				"type": "notice",
+				"state": "pikachu",
+				"highlight": [
+					{
+						"copy": "The status of",
+						"color": false
+					},
+					{
+						"copy": "thing",
+						"color": true
+					},
+					{
+						"copy": "is notable",
+						"color": false
+					}
+				],
+				"content": "The quick brown fox jumped over the lazy dogs!",
+				"actions": {
+					"button": true,
+					"link": true
+				}
+			},
+			"display_html": false,
+			"brands": [
+				"master",
+				"internal"
+			]
+		},
+		{
+			"title": "Action: Custom",
+			"name": "action-custom",
+			"description": "Sass users may customise action messages. See the README for more information.",
+			"data": {
+				"type": "action",
+				"state": "pikachu",
+				"highlight": [
+					{
+						"copy": "Are you enjoying",
+						"color": false
+					},
+					{
+						"copy": "thing",
+						"color": true
+					},
+					{
+						"copy": "?",
+						"color": false
+					}
+				],
+				"content": "The quick brown fox jumped over the lazy dogs!",
+				"actions": {
+					"button": true,
+					"link": true
+				},
+				"noCloseButton": true
+			},
+			"display_html": false,
 			"brands": [
 				"internal"
 			]

--- a/src/scss/_state.scss
+++ b/src/scss/_state.scss
@@ -68,10 +68,6 @@
 	.o-message__content-highlight-color {
 		color: $highlight-color;
 	}
-	.o-message__content-highlight {
-		$highlight-transform: _oMessageGet('highlight-text-transform', $from: $opts);
-		text-transform: if($highlight-transform, unquote($highlight-transform), null);
-	}
 
 	// content links
 	.o-message__content-main a,

--- a/src/scss/_state.scss
+++ b/src/scss/_state.scss
@@ -1,67 +1,140 @@
+@mixin oMessageAddState($name, $opts, $types) {
+	// If no options are given assume we are adding a default state.
+	// @see _brand.scss for configuration by name.
+	$opts: if($opts, $opts, $name);
+	.o-message.o-message--#{$name} {
+		@include _oMessageState($name, $opts, $types);
+	}
+}
+
 /// message state styling
-/// @param {String} $state - the name of the state for the message ('success', 'neutral', 'error', 'warning', 'warning-light', 'inform', 'inform-inverse')
+/// @param {String} $opts - the name of the state for the message ('success', 'neutral', 'error', 'warning', 'warning-light', 'inform', 'inform-inverse')
 /// @access private
-@mixin _oMessageState ($state) {
+@mixin _oMessageState($name, $opts, $types) {
+	$error-message: 'Cannot add o-message state "#{$name}"';
 	// get foreground colour
-	$foreground-color: _oMessageGet('foreground-color', $from: $state);
-	$foreground-color: if(type-of($foreground-color) == 'string', oColorsByName($foreground-color), $foreground-color);
+	$foreground-color-arg: _oMessageGet('foreground-color', $from: $opts);
+	$foreground-color: if(
+		type-of($foreground-color-arg) == 'string',
+		oColorsByName($foreground-color-arg),
+		$foreground-color-arg
+	);
+	// get highlight colour
+	$highlight-color-arg: _oMessageGet('highlight-color', $from: $opts);
+	$highlight-color: if(
+		type-of($highlight-color-arg) == 'string',
+		oColorsByName($highlight-color-arg),
+		$highlight-color-arg
+	);
 	// get background colour
-	$background-color: _oMessageGet('background-color', $from: $state);
-	$background-color: if(type-of($background-color) == 'string', oColorsByName($background-color), $background-color);
+	$background-color-arg: _oMessageGet('background-color', $from: $opts);
+	$background-color: if(
+		type-of($background-color-arg) == 'string',
+		oColorsByName($background-color-arg),
+		$background-color-arg
+	);
 
-	.o-message.o-message--#{$state} {
-		color: $foreground-color;
-		background-color: $background-color;
-
-		.o-message__content-main a,
-		.o-message__content-additional a {
-			@include oTypographyLink(
-				$theme: (
-					'base':  $foreground-color,
-					'hover':  $foreground-color,
-					'context':  $background-color
-				),
-				$include-base-styles: false
-			);
+	// Confirm minimum foreground contrast ratio.
+	@if $foreground-color {
+		$foreground-contrast: oColorsGetContrastRatio(
+			$foreground-color,
+			$background-color
+		);
+		@if($foreground-contrast < 4.5) {
+			@error ('#{$error-message}: The foreground colour ' +
+			'"#{$foreground-color-arg}" and background colour ' +
+			'"#{$background-color-arg}" do not pass WCAG AA contrast checks.');
 		}
+	}
 
-		.o-message__actions__primary {
-			@include oButtonsContent((
-				'type': 'secondary',
-				'theme': (
-					'color': $foreground-color,
-					'context': $background-color
-				)
-			), $include-base-styles: false);
-			margin-right: oSpacingByName('s6');
+	// Confirm minimum highlight contrast ratio.
+	@if $highlight-color {
+		$highlight-contrast: oColorsGetContrastRatio(
+			$highlight-color,
+			$background-color
+		);
+		@if($highlight-contrast < 4.5) {
+			@error ('#{$error-message}: The highlight colour ' +
+			'"#{$highlight-color-arg}" and background colour ' +
+			'"#{$background-color-arg}" do not pass WCAG AA contrast checks.');
 		}
+	}
 
-		.o-message__actions__secondary {
-			@include oTypographyLink(
-				$theme: (
-					'base':  $foreground-color,
-					'hover':  $foreground-color,
-					'context':  $background-color
-				),
-				$include-base-styles: false
-			);
-		}
+	// set default foreground and background colour
+	color: $foreground-color;
+	background-color: $background-color;
 
-		@if (_oMessageGet('icon', $from: $state)) {
-			.o-message__container:before {
-				@include _oMessageIcon(_oMessageGet('icon', $from: $state), $foreground-color, $_o-message-alert-icon-size);
-				min-width: $_o-message-alert-icon-size * 1px;
-				position: absolute;
-			}
-		}
+	// class to set the highlight colour
+	.o-message__content-highlight-color {
+		color: $highlight-color;
+	}
+	.o-message__content-highlight {
+		$highlight-transform: _oMessageGet('highlight-text-transform', $from: $opts);
+		text-transform: if($highlight-transform, unquote($highlight-transform), null);
+	}
 
-		.o-message__close {
-			@include _oMessageIcon('cross', $foreground-color, $_o-message-close-icon-size);
+	// content links
+	.o-message__content-main a,
+	.o-message__content-additional a {
+		@include oTypographyLink(
+			$theme: (
+				'base':  $foreground-color,
+				'hover':  $foreground-color,
+				'context':  $background-color
+			),
+			$include-base-styles: false
+		);
+	}
+
+	// action button
+	.o-message__actions__primary {
+		$button-type: _oMessageGet('button-type', $from: $opts);
+		$button-type: if($button-type, $button-type, 'secondary');
+		$button-color: if($highlight-color, $highlight-color, $foreground-color);
+		@include oButtonsContent((
+			'type': $button-type,
+			'theme': (
+				'color': $button-color,
+				'context': $background-color
+			)
+		), $include-base-styles: false);
+		margin-right: oSpacingByName('s6');
+	}
+
+	// action link
+	.o-message__actions__secondary {
+		@include oTypographyLink(
+			$theme: (
+				'base':  $foreground-color,
+				'hover':  $foreground-color,
+				'context':  $background-color
+			),
+			$include-base-styles: false
+		);
+	}
+
+	// state icon, only for alert messages
+	$state-icon: _oMessageGet('icon', $from: $opts);
+	$supports-alert-type: index($types, 'alert');
+	@if ($supports-alert-type and not $state-icon) {
+		@error '#{$error-message}: To support the "alert" type include an "icon". ' +
+		'If an alert with icon is not needed update the "types" argument.';
+	}
+
+	@if $supports-alert-type and $state-icon {
+		&.o-message--alert .o-message__container:before {
+			@include _oMessageIcon($state-icon, $foreground-color, $_o-message-alert-icon-size);
+			min-width: $_o-message-alert-icon-size * 1px;
 			position: absolute;
-			top: ($_o-message-close-icon-size / 2) * 1px;
-			right: oSpacingByName('s2');
-			vertical-align: middle;
-			border: 0;
 		}
+	}
+
+	.o-message__close {
+		@include _oMessageIcon('cross', $foreground-color, $_o-message-close-icon-size);
+		position: absolute;
+		top: ($_o-message-close-icon-size / 2) * 1px;
+		right: oSpacingByName('s2');
+		vertical-align: middle;
+		border: 0;
 	}
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -20,3 +20,24 @@ $_o-message-text-spacing: ($_o-message-line-height / 2) * 1px;
 ///
 /// @type List
 $o-message-states: ('error', 'inform', 'inform-inverse', 'neutral', 'success', 'warning', 'warning-light');
+
+/// List of message types
+///
+/// @type List
+$o-message-types: ('alert', 'notice', 'action');
+
+/// A list of states to the types of message they
+/// may apply to.
+///
+/// @access private
+/// @type Map
+$_o-message-states-to-types: (
+	'inform': ('action', 'notice'),
+	'inform-inverse': ('action'),
+	'success': ('alert'),
+	'neutral': ('alert'),
+	'error': ('alert'),
+	'alert': ('success', 'neutral', 'error'),
+	'warning': ('notice'),
+	'warning-light': ('notice')
+);


### PR DESCRIPTION
**Note:
Using uppercase is still up for discussion, so it has been 
removed as an Origami option for now until we discuss
more with the broader design team. In the meantime it
can be applied by projects manually to experiment. 
The uppercase option was removed after the
current screenshots was taken.**


Example "alert" message with custom "pikachu" state 
(let's pretent the profile icon is a Pokémon trainer):
![Screenshot 2020-03-09 at 18 57 17](https://user-images.githubusercontent.com/10405691/76247766-fb79ac80-6237-11ea-8c1c-44ba1ce8d760.png)

Example "notice" message with custom "pikachu" state:
![Screenshot 2020-03-09 at 18 57 06](https://user-images.githubusercontent.com/10405691/76247778-003e6080-6238-11ea-9ad6-3cbea7a7df40.png)

Example "action" message with custom "pikachu" state:
![Screenshot 2020-03-09 at 18 56 18](https://user-images.githubusercontent.com/10405691/76247851-219f4c80-6238-11ea-9b0a-16be2766e343.png)

https://github.com/Financial-Times/o-message/issues/74