### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -1,4 +1,4 @@
-import Message from './../../main.js';
+import Message from './../../main.js.js';
 
 const options = {
 	type: 'alert',

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-import Message from './src/js/message';
+import Message from './src/js/message.js';
 
 const constructAll = () => {
 	Message.init();

--- a/src/js/message.js
+++ b/src/js/message.js
@@ -1,4 +1,4 @@
-import construct from './construct-element';
+import construct from './construct-element.js';
 
 /**
  * An object of options to configure a message instance.

--- a/test/contruct-element.test.js
+++ b/test/contruct-element.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import construct from '../src/js/construct-element';
-import fixtures from './helpers/fixtures';
+import construct from '../src/js/construct-element.js';
+import fixtures from './helpers/fixtures.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Message from '../src/js/message';
-import construct from '../src/js/construct-element';
-import fixtures from './helpers/fixtures';
+import Message from '../src/js/message.js';
+import construct from '../src/js/construct-element.js';
+import fixtures from './helpers/fixtures.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing