### PR TITLE
Add a `feedback` state for the `notice` o-message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ However, not every message accepts every state, or every layout, and not every m
 ---|:---|:---|:---
 **action message** | `inform`, `inform-inverse` | default | internal, whitelabel
 **alert message** | `success`, `neutral`, `error` | default, inner | all
-**notice message** | `inform`, `warning`, `warning-light` | default, inner | master: `inform` state only <br> internal: all states <br> whitelabel: `inform` state only
+**notice message** | `inform`, `feedback`, `warning`, `warning-light` | default, inner | master: `inform` or `feedback` state only <br> internal: all states <br> whitelabel: `inform` state only
 
 
 ## Markup
@@ -49,7 +49,7 @@ However, not every message accepts every state, or every layout, and not every m
 All messages have the same markup. What will style them differently are the following modifiers:
 
 - `type`: one of `o-message--action`, `o-message--alert`, `o-message--notice`
-- `state`: one of `o-message--success`, `o-message--neutral`, `o-message--error`, `o-message--warning`, `o-message--warning-light`, `o-message--inform`, `o-message--inform-inverse`
+- `state`: one of `o-message--success`, `o-message--neutral`, `o-message--error`, `o-message--feedback`, `o-message--warning`, `o-message--warning-light`, `o-message--inform`, `o-message--inform-inverse`
 - `layout`: currently only `o-message--inner`
 
 _Note: as mentioned in the description of the [message types](#message-types), not all states will work for all message types. In addition to that, the layout modifier only applies to `alert` and `notice` type messages._

--- a/main.scss
+++ b/main.scss
@@ -23,10 +23,10 @@
 ///     	'types': ('alert'),
 ///     	'states': ('error', 'success'),
 ///     ));
-/// @param {Map} $opts ['types': ('alert', 'notice', 'action), 'states': ('error', 'success', 'inform', 'neutral', 'inform-inverse', 'warning', 'warning-light'), 'layouts': ('inner')]
+/// @param {Map} $opts ['types': ('alert', 'notice', 'action), 'states': ('error', 'success', 'inform', 'neutral', 'inform-inverse', 'warning', 'warning-light', 'feedback'), 'layouts': ('inner')]
 @mixin oMessage($opts: (
 	'types': ('action', 'alert', 'notice'),
-	'states': ('error', 'success', 'neutral', 'inform', 'inform-inverse', 'warning', 'warning-light'),
+	'states': ('error', 'success', 'neutral', 'inform', 'inform-inverse', 'warning', 'warning-light', 'feedback'),
 	'layouts': ('inner')
 )) {
 	$types: map-get($opts, 'types');

--- a/origami.json
+++ b/origami.json
@@ -210,6 +210,41 @@
 			]
 		},
 		{
+			"title": "Notice: Feedback",
+			"name": "notice-feedback",
+			"description": "Notice message to emit a strong feedback",
+			"data": {
+				"type": "notice",
+				"state": "feedback",
+				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact.",
+				"actions": {
+					"button": true
+				}
+			},
+			"brands": [
+				"master",
+				"internal"
+			]
+		},
+		{
+			"title": "Notice Inner: Feedback",
+			"name": "notice-inner-feedback",
+			"description": "Notice message to request feedback",
+			"data": {
+				"inner": true,
+				"type": "notice",
+				"state": "feedback",
+				"content": "There are lazy dogs, maybe in a field, maybe not. It's important that you are informed of this fact. There may also be a fox. This is unconfirmed.",
+				"actions": {
+					"button": true
+				}
+			},
+			"brands": [
+				"master",
+				"internal"
+			]
+		},
+		{
 			"title": "Action: Inform Inverse",
 			"name": "action-inform-inverse",
 			"description": "Action message, displaying a call to action",

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -22,6 +22,13 @@ $_o-message-shared-brand-variables: (
 		'foreground-color': oColorsMix('black', 'crimson', $percentage: 12.5),
 		'background-color': oColorsMix('crimson', $percentage: 10),
 		'icon': 'warning-alt'
+	),
+	'feedback': (
+		'foreground-color': oColorsByUsecase('body', 'text'),
+		'highlight-color': oColorsByName('teal'),
+		'button-type': 'primary',
+		'background-color': oColorsByName('white'),
+		'text-align': center
 	)
 );
 
@@ -44,7 +51,8 @@ $_o-message-shared-brand-variables: (
 			'inform',
 			'neutral',
 			'notice',
-			'success'
+			'success',
+			'feedback'
 		)
 	));
 }
@@ -84,7 +92,8 @@ $_o-message-shared-brand-variables: (
 			'notice',
 			'success',
 			'warning',
-			'warning-light'
+			'warning-light',
+			'feedback'
 		)
 	));
 }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -10,7 +10,7 @@
 	@return oBrandSupportsVariant($component: 'o-message', $variant: $variant);
 }
 
-/// Shared variables between master and internal brands.
+/// Shared variables between all brands
 /// @access private
 $_o-message-shared-brand-variables: (
 	'success': (
@@ -22,19 +22,19 @@ $_o-message-shared-brand-variables: (
 		'foreground-color': oColorsMix('black', 'crimson', $percentage: 12.5),
 		'background-color': oColorsMix('crimson', $percentage: 10),
 		'icon': 'warning-alt'
-	),
-	'feedback': (
-		'foreground-color': oColorsByUsecase('body', 'text'),
-		'highlight-color': oColorsByName('teal'),
-		'button-type': 'primary',
-		'background-color': oColorsByName('white'),
-		'text-align': center
 	)
 );
 
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-message', 'master', (
 		'variables': map-merge($_o-message-shared-brand-variables, (
+			'feedback': (
+				'foreground-color': oColorsByUsecase('body', 'text'),
+				'highlight-color': oColorsByName('teal'),
+				'button-type': 'primary',
+				'background-color': oColorsByName('white'),
+				'text-align': center
+			),
 			'neutral': (
 				'foreground-color': 'black',
 				'background-color': 'white-60',
@@ -60,6 +60,13 @@ $_o-message-shared-brand-variables: (
 @if oBrandGetCurrentBrand() == 'internal' {
 	@include oBrandDefine('o-message', 'internal', (
 		'variables': map-merge($_o-message-shared-brand-variables, (
+			'feedback': (
+				'foreground-color': oColorsByUsecase('body', 'text'),
+				'highlight-color': oColorsByName('teal'),
+				'button-type': 'primary',
+				'background-color': oColorsByName('white'),
+				'text-align': center
+			),
 			'neutral': (
 				'foreground-color': 'black',
 				'background-color': 'slate-white-15',

--- a/src/scss/_state.scss
+++ b/src/scss/_state.scss
@@ -63,6 +63,7 @@
 	// set default foreground and background colour
 	color: $foreground-color;
 	background-color: $background-color;
+	text-align: _oMessageGet('text-align', $from: $opts);
 
 	// class to set the highlight colour
 	.o-message__content-highlight-color {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -19,7 +19,7 @@ $_o-message-text-spacing: ($_o-message-line-height / 2) * 1px;
 /// List of states that can be applied to alert type messages
 ///
 /// @type List
-$o-message-states: ('error', 'inform', 'inform-inverse', 'neutral', 'success', 'warning', 'warning-light');
+$o-message-states: ('error', 'inform', 'inform-inverse', 'neutral', 'success', 'warning', 'warning-light', 'feedback');
 
 /// List of message types
 ///
@@ -32,6 +32,7 @@ $o-message-types: ('alert', 'notice', 'action');
 /// @access private
 /// @type Map
 $_o-message-states-to-types: (
+	'feedback': ('notice'),
 	'inform': ('action', 'notice'),
 	'inform-inverse': ('action'),
 	'success': ('alert'),


### PR DESCRIPTION
- Uses a teal highlight colour for the primary button.
- Uses centre alignment.

Currently a similar style is made in a custom way on the graphics
page. It uses a very heavily modified version of o-banner, in a
way o-banner was never intended for. This style may also be used
on the app.

On site messaging is currently under review so this is very much
a temporary new variant inline with the direction of that work.

![Screenshot 2020-11-03 at 12 27 40](https://user-images.githubusercontent.com/10405691/97985606-6469f200-1dd0-11eb-8539-0abf581ce640.png)
![Screenshot 2020-11-03 at 12 27 33](https://user-images.githubusercontent.com/10405691/97985614-659b1f00-1dd0-11eb-884a-d84387828895.png)
