### PR TITLE
Correct the alignment of the feedback notice.

### DIFF
--- a/src/scss/_state.scss
+++ b/src/scss/_state.scss
@@ -98,6 +98,10 @@
 		margin-right: oSpacingByName('s6');
 	}
 
+	.o-message__actions__primary:only-child {
+		margin-right: 0;
+	}
+
 	// action link
 	.o-message__actions__secondary {
 		@include oTypographyLink(


### PR DESCRIPTION
The feedback notice is centre aligned. Which means when only the
primary action is shown, without a text link, the margin on the
primary action is noticeable and causes misalignment.

before
![Screenshot 2020-11-03 at 15 07 53](https://user-images.githubusercontent.com/10405691/98003361-925a3100-1de6-11eb-99da-d65011cf7389.png)

after
![Screenshot 2020-11-03 at 15 07 47](https://user-images.githubusercontent.com/10405691/98003386-9be39900-1de6-11eb-83f4-dfe35287b4ab.png)
