### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/src/js/message.js
+++ b/src/js/message.js
@@ -147,8 +147,8 @@ class Message {
 		}
 		return Object.keys(messageElement.dataset).reduce((options, key) => {
 
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^oMessage(\w)(\w+)$/)) {
 				return options;
 			}
 


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214