### PR TITLE
Align feedback notices centre when there is one line of copy.

### DIFF
--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -33,7 +33,7 @@ $_o-message-shared-brand-variables: (
 				'highlight-color': oColorsByName('teal'),
 				'button-type': 'primary',
 				'background-color': oColorsByName('white'),
-				'text-align': center
+				'align': center
 			),
 			'neutral': (
 				'foreground-color': 'black',
@@ -65,7 +65,7 @@ $_o-message-shared-brand-variables: (
 				'highlight-color': oColorsByName('teal'),
 				'button-type': 'primary',
 				'background-color': oColorsByName('white'),
-				'text-align': center
+				'align': center
 			),
 			'neutral': (
 				'foreground-color': 'black',

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -82,7 +82,11 @@
 	// set default foreground and background colour
 	color: $foreground-color;
 	background-color: $background-color;
-	text-align: _oMessageGet('text-align', $from: $opts);
+	text-align: _oMessageGet('align', $from: $opts);
+
+	.o-message__container {
+		justify-content: _oMessageGet('align', $from: $opts);
+	}
 
 	// class to set the highlight colour
 	.o-message__content-highlight-color {


### PR DESCRIPTION
`text-align: center` gave the feedback message a centred appearance
when copy filled the length of the message and wrapped onto a second
line but appeared to align left otherwise. Now copy is always
aligned centre, most notably on tablet and desktop viewport sizes.

Before:
![Screenshot 2021-03-16 at 11 14 37](https://user-images.githubusercontent.com/10405691/111300288-d2f57100-8648-11eb-8a0a-c8b9981fc417.png)

After:
![Screenshot 2021-03-16 at 11 14 26](https://user-images.githubusercontent.com/10405691/111300303-d8eb5200-8648-11eb-995d-4cca691a8f2f.png)
