### PR TITLE
Match padding left and right given a close button and centred message

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -117,19 +117,13 @@
 	// Alert/notice types of message are similar but the alert message has extra
 	// iconography.
 	@if $alert or $notice {
-		// Icon svgs are drawn to a 40px grid with 10px whitespace either side.
-		// This is what the size of the close icon would be without the whitespace.
-		$true-close-icon-size: $_o-message-close-icon-size / 2;
-
 		// By default alert and notice messages are dismissible. Unless
 		// configured otherwise, create space to accommodate the close button
 		// with padding, so the close button can be added by JS without reflow.
 		// @deprecated the `data-close` attribute is deprecated in favour of `data-o-message-close`.
-		.o-message--notice:not([data-close="false"]) .o-message__container,
-		.o-message--alert:not([data-close="false"]) .o-message__container,
-		.o-message--notice:not([data-o-message-close="false"]) .o-message__container,
-		.o-message--alert:not([data-o-message-close="false"]) .o-message__container {
-			padding-right: calc(#{$true-close-icon-size} + #{oSpacingByName('s4') * 2});
+		.o-message--notice:not([data-close="false"]):not([data-o-message-close="false"]) .o-message__container,
+		.o-message--alert:not([data-close="false"]):not([data-o-message-close="false"]) .o-message__container {
+			padding-right: $_o-message-close-inline-spacing;
 		}
 
 		.o-message--notice .o-message__close,

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -84,8 +84,15 @@
 	background-color: $background-color;
 	text-align: _oMessageGet('align', $from: $opts);
 
+	// when centred with a close button match the right and left padding
 	.o-message__container {
 		justify-content: _oMessageGet('align', $from: $opts);
+	}
+
+	&:not([data-o-message-close="false"]) .o-message__container {
+		@if _oMessageGet('align', $from: $opts) == 'center' {
+			padding-left: $_o-message-close-inline-spacing;
+		}
 	}
 
 	// class to set the highlight colour

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -15,6 +15,13 @@ $_o-message-default-content-spacing:  oSpacingByName('s4');
 $_o-message-default-block-spacing:  oSpacingByName('s4');
 $_o-message-default-inline-spacing:  oSpacingByName('s6');
 
+
+// Spacing for close button area.
+// Icon svgs are drawn to a 40px grid with 10px whitespace either side.
+// This is what the size of the close icon would be without the whitespace.
+$_o-message-true-close-icon-size: $_o-message-close-icon-size / 2;
+$_o-message-close-inline-spacing:  calc(#{$_o-message-true-close-icon-size} + #{oSpacingByName('s4') * 2});
+
 /// List of states that can be applied to alert type messages
 ///
 /// @type List


### PR DESCRIPTION
Fixes a bug where the padding on the right for the close button
would be present on messages with no close button.

When there is no close button:
![Screenshot 2021-03-16 at 17 21 38](https://user-images.githubusercontent.com/10405691/111352489-21703300-867c-11eb-9da9-cc633cb8c754.png)


When there is a close button padding on both sides increases for the centred feedback message:
![Screenshot 2021-03-16 at 17 19 46](https://user-images.githubusercontent.com/10405691/111352561-35b43000-867c-11eb-8841-e7e11d023257.png)

Previously only the right side padding increased to fit the close button. This does not work well for centred messages as the message is then not truly centred:
![Screenshot 2021-03-16 at 17 12 23](https://user-images.githubusercontent.com/10405691/111352608-4369b580-867c-11eb-8c15-f19f2be77e4e.png)
